### PR TITLE
Flag hq added and main of promethee simplified

### DIFF
--- a/promethee/main.cpp
+++ b/promethee/main.cpp
@@ -29,6 +29,24 @@ void validateInput(Data data, int nMatrices) {
   }
 }
 
+vector<string> convertToVector(int argc, char * argv[]){
+  vector<string> args;
+  for(int i = 1; i < argc; i++) args.push_back(argv[i]);
+  return args;
+}
+
+bool hasFlag(vector<string> & args, string flag){
+  int size = args.size();
+  for(int i = 0; i < size; i++){
+    if(args[i] == flag){
+      for(int j = i + 1; j < size; j++) args[j - 1] = args[j];
+      args.resize(size - 1);
+      return true;
+    }
+  }
+  return false;
+}
+
 int main(int argc, char *argv[]){
 
   //lambdas
@@ -87,21 +105,20 @@ int main(int argc, char *argv[]){
   const string INPUT_FILE_SUFFIX = ".input";
   const string META_FILE_SUFFIX = ".meta";
 
-  const int INPUT_DIRECTORY_INDEX = 1;
-  const int META_DIRECTORY_INDEX = 2;
-  const int OUTPUT_DIRECTORY_INDEX = 3;
-  const int IS_OPT_FLAG_INDEX = 4;
+  const int INPUT_DIRECTORY_INDEX = 0;
+  const int META_DIRECTORY_INDEX = 1;
+  const int OUTPUT_DIRECTORY_INDEX = 2;
 
-  bool opt_flag = true;
+  vector<string> args = convertToVector(argc, argv);
 
-  const string PATH_TO_OUTPUT_DIRECTORY(validDir(argv[OUTPUT_DIRECTORY_INDEX]));
+  bool opt_flag = !hasFlag(args, "-V");
+  bool hq_flag = hasFlag(args, "-HQ");
 
-  if(argc < 4 || argc > 5){
+  const string PATH_TO_OUTPUT_DIRECTORY = validDir(args[OUTPUT_DIRECTORY_INDEX]);
+
+  if(args.size() != 3){
     cerr << "Arguments are invalid!";
     exit(0);
-  }else if(argc == 5){
-    if(string(argv[IS_OPT_FLAG_INDEX]) == "-V")
-      opt_flag = false;
   }
 
   // argv in format (name_of_file, weight)
@@ -114,13 +131,14 @@ int main(int argc, char *argv[]){
   struct dirent *directory;
 
   /* input directory */ 
-  string inputDirectory(validDir(argv[INPUT_DIRECTORY_INDEX]));
+  string inputDirectory = validDir(args[INPUT_DIRECTORY_INDEX]);
   valFiles = filterDirectoryFiles(inputDirectory, INPUT_FILE_SUFFIX);
 
   /* meta directory */ 
-  string metaDirectory(validDir(argv[META_DIRECTORY_INDEX]));
+  string metaDirectory = validDir(args[META_DIRECTORY_INDEX]);
   metaFiles = filterDirectoryFiles(metaDirectory, META_FILE_SUFFIX);
 
+  cout << inputDirectory << " " << metaDirectory << " " << PATH_TO_OUTPUT_DIRECTORY << endl;
   /* output directory */
   filterDirectoryFiles(PATH_TO_OUTPUT_DIRECTORY, "");
 

--- a/promethee/main.cpp
+++ b/promethee/main.cpp
@@ -113,13 +113,20 @@ int main(int argc, char *argv[]){
 
   bool opt_flag = !hasFlag(args, "-V");
   bool hq_flag = hasFlag(args, "-HQ");
+  int divideBy = -1;
 
   const string PATH_TO_OUTPUT_DIRECTORY = validDir(args[OUTPUT_DIRECTORY_INDEX]);
 
-  if(args.size() != 3){
-    cerr << "Arguments are invalid!";
+  if(args.size() < 3 || args.size() > 4){
+    cerr << "Error: Arguments are invalid!";
     exit(0);
   }
+
+  if(args.size() == 4){
+    divideBy = atoi(args.back().c_str());
+  }
+
+  // cout << divideBy << endl;
 
   // argv in format (name_of_file, weight)
   Data data = Data();
@@ -138,7 +145,6 @@ int main(int argc, char *argv[]){
   string metaDirectory = validDir(args[META_DIRECTORY_INDEX]);
   metaFiles = filterDirectoryFiles(metaDirectory, META_FILE_SUFFIX);
 
-  cout << inputDirectory << " " << metaDirectory << " " << PATH_TO_OUTPUT_DIRECTORY << endl;
   /* output directory */
   filterDirectoryFiles(PATH_TO_OUTPUT_DIRECTORY, "");
 
@@ -146,7 +152,7 @@ int main(int argc, char *argv[]){
   sort(metaFiles.begin(), metaFiles.end());
 
   if(valFiles != metaFiles) { // files don't match
-    cout << "Error: not every file has its metadata accordingly or vice versa\n";
+    cerr << "Error: not every file has its metadata accordingly or vice versa\n";
     return 0;
   }
 
@@ -160,7 +166,7 @@ int main(int argc, char *argv[]){
     res = new PrometheeOpt();
   else
     res = new PrometheeVanilla();
-  res->init(valFiles, metaFiles, PATH_TO_OUTPUT_DIRECTORY);
+  res->init(valFiles, metaFiles, PATH_TO_OUTPUT_DIRECTORY, divideBy);
   res->process();
   return 0;
 }

--- a/promethee/main.cpp
+++ b/promethee/main.cpp
@@ -1,65 +1,8 @@
-#include "types.h"
-#include "data.h"
-#include "normalize.h"
 #include "optimized/promethee_opt.h"
-#include "inputreader.h"
-#include "outputwriter.h"
 #include "vanilla/promethee_vanilla.h"
-#include <iostream>
-#include <dirent.h>
+#include "parse_args.h"
 
 using namespace std;
-
-void validateInput(Data data, int nMatrices) {
-  int nLines = data.matrices[0].size(), nColumns;
-
-  for(int i = 1; i < nMatrices; i++) {
-    if(nLines != data.matrices[i].size()) {
-      cerr << "Invalid input file (quantity of lines does not match)" << endl;
-      exit(0);
-    }
-
-    for(int j = 0; j < nLines; j++) {
-      nColumns = data.matrices[0][j].size();
-      if(nColumns != data.matrices[i][j].size()) {
-        cerr << "Invalid input file (quantity of columns does not match)" << endl;
-        exit(0);
-      }
-    }
-  }
-}
-
-vector<string> convertToVector(int argc, char * argv[]){
-  vector<string> args;
-  for(int i = 1; i < argc; i++) args.push_back(argv[i]);
-  return args;
-}
-
-bool hasFlag(vector<string> & args, string flag){
-  int size = args.size();
-  for(int i = 0; i < size; i++){
-    if(args[i] == flag){
-      for(int j = i + 1; j < size; j++) args[j - 1] = args[j];
-      args.resize(size - 1);
-      return true;
-    }
-  }
-  return false;
-}
-
-string getCmdOption(vector<string> & args, string cmd){
-  int size = args.size();
-  cmd = cmd + "=";
-  for(int i = 0; i < size; i++){
-    if(args[i].find(cmd) == 0){
-      string res = args[i].substr(cmd.size());
-      for(int j = i + 1; j < size; j++) args[j - 1] = args[j];
-      args.resize(size - 1);
-      return res;
-    }
-  }
-  return "";
-}
 
 int main(int argc, char *argv[]){
 

--- a/promethee/optimized/promethee_opt.cpp
+++ b/promethee/optimized/promethee_opt.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include "../inputreader.h"
 #include "../outputwriter.h"
+#include "../parse_directory.h"
 
 Data PrometheeOpt::readData(){
   InputReader inputReader = InputReader();
@@ -15,6 +16,40 @@ Data PrometheeOpt::readData(){
   }
   data.normalizeWeights();
   return data;
+}
+
+void PrometheeOpt::init(vector<string> args, int divideBy){
+  this->divideBy = divideBy;
+
+  const string INPUT_FILE_SUFFIX = ".input";
+  const string META_FILE_SUFFIX = ".meta";
+
+  const int INPUT_DIRECTORY_INDEX = 0;
+  const int META_DIRECTORY_INDEX = 1;
+  const int OUTPUT_DIRECTORY_INDEX = 2;
+
+  string inputDirectory = validDir(args[INPUT_DIRECTORY_INDEX]);
+  string metaDirectory = validDir(args[META_DIRECTORY_INDEX]);
+  string outputDirectory = validDir(args[OUTPUT_DIRECTORY_INDEX]);
+
+  vector<string> inputFiles = filterDirectoryFiles(inputDirectory, INPUT_FILE_SUFFIX);
+  vector<string> metaFiles = filterDirectoryFiles(metaDirectory, META_FILE_SUFFIX);
+
+  sort(inputFiles.begin(), inputFiles.end());
+  sort(metaFiles.begin(), metaFiles.end());
+
+  if(inputFiles != metaFiles){ // files don't match
+
+  }
+
+  for(int i = 0; i < inputFiles.size(); i++){
+    inputFiles[i] = inputDirectory + inputFiles[i] + INPUT_FILE_SUFFIX;
+    metaFiles[i] = metaDirectory + metaFiles[i] + META_FILE_SUFFIX;
+  }
+
+  this->inputFiles = inputFiles;
+  this->metaFiles = metaFiles;
+  this->pathToOutput = outputDirectory;
 }
 
 void PrometheeOpt::process() {

--- a/promethee/optimized/promethee_opt.cpp
+++ b/promethee/optimized/promethee_opt.cpp
@@ -20,36 +20,7 @@ Data PrometheeOpt::readData(){
 
 void PrometheeOpt::init(vector<string> args, int divideBy){
   this->divideBy = divideBy;
-
-  const string INPUT_FILE_SUFFIX = ".input";
-  const string META_FILE_SUFFIX = ".meta";
-
-  const int INPUT_DIRECTORY_INDEX = 0;
-  const int META_DIRECTORY_INDEX = 1;
-  const int OUTPUT_DIRECTORY_INDEX = 2;
-
-  string inputDirectory = validDir(args[INPUT_DIRECTORY_INDEX]);
-  string metaDirectory = validDir(args[META_DIRECTORY_INDEX]);
-  string outputDirectory = validDir(args[OUTPUT_DIRECTORY_INDEX]);
-
-  vector<string> inputFiles = filterDirectoryFiles(inputDirectory, INPUT_FILE_SUFFIX);
-  vector<string> metaFiles = filterDirectoryFiles(metaDirectory, META_FILE_SUFFIX);
-
-  sort(inputFiles.begin(), inputFiles.end());
-  sort(metaFiles.begin(), metaFiles.end());
-
-  if(inputFiles != metaFiles){ // files don't match
-
-  }
-
-  for(int i = 0; i < inputFiles.size(); i++){
-    inputFiles[i] = inputDirectory + inputFiles[i] + INPUT_FILE_SUFFIX;
-    metaFiles[i] = metaDirectory + metaFiles[i] + META_FILE_SUFFIX;
-  }
-
-  this->inputFiles = inputFiles;
-  this->metaFiles = metaFiles;
-  this->pathToOutput = outputDirectory;
+  parseInputAndMeta(args, this->inputFiles, this->metaFiles, this->pathToOutput);
 }
 
 void PrometheeOpt::process() {

--- a/promethee/optimized/promethee_opt.cpp
+++ b/promethee/optimized/promethee_opt.cpp
@@ -31,6 +31,7 @@ void PrometheeOpt::process() {
   Matrix negativeFlow = Matrix(nlines, MatrixLine(ncolumns, 0.0));
   Matrix netFlow = Matrix(nlines, MatrixLine(ncolumns, 0.0));
   
+  int studyArea = 0;
   // applying the optimized promethee method (using linear preference function only)
   for(int criteria = 0; criteria < ncriterias; criteria++){
 
@@ -50,6 +51,7 @@ void PrometheeOpt::process() {
 
     sort(values.begin(), values.end());
 
+    studyArea = values.size();
     int nvalues = values.size();
     vector<ldouble> cummulative(nvalues, 0);
 
@@ -75,11 +77,12 @@ void PrometheeOpt::process() {
     }
   }
 
+  int denominator = (this->divideBy != -1 ? this->divideBy : studyArea);
   // applying a not standard normalization (but used by grass)
   for(int line = 0; line < nlines; line++)
     for(int column = 0; column < ncolumns; column++){
-      positiveFlow[line][column] /= ncriterias;
-      negativeFlow[line][column] /= ncriterias;
+      positiveFlow[line][column] /= denominator;
+      negativeFlow[line][column] /= denominator;
     }
 
   // calculating global flow

--- a/promethee/optimized/promethee_opt.h
+++ b/promethee/optimized/promethee_opt.h
@@ -8,8 +8,13 @@
   #include <algorithm>
   
   struct PrometheeOpt : Promethee {
+
+    string pathToOutput;
+    vector<string> inputFiles, metaFiles;
+
     Data readData();
     void process();
+    void init(vector<string> args, int divideBy);
   };
 
 #endif

--- a/promethee/parse_args.cpp
+++ b/promethee/parse_args.cpp
@@ -1,0 +1,33 @@
+#include "parse_args.h"
+
+vector<string> convertToVector(int argc, char * argv[]){
+  vector<string> args;
+  for(int i = 1; i < argc; i++) args.push_back(argv[i]);
+  return args;
+}
+
+bool hasFlag(vector<string> & args, string flag){
+  int size = args.size();
+  for(int i = 0; i < size; i++){
+    if(args[i] == flag){
+      for(int j = i + 1; j < size; j++) args[j - 1] = args[j];
+      args.resize(size - 1);
+      return true;
+    }
+  }
+  return false;
+}
+
+string getCmdOption(vector<string> & args, string cmd){
+  int size = args.size();
+  cmd = cmd + "=";
+  for(int i = 0; i < size; i++){
+    if(args[i].find(cmd) == 0){
+      string res = args[i].substr(cmd.size());
+      for(int j = i + 1; j < size; j++) args[j - 1] = args[j];
+      args.resize(size - 1);
+      return res;
+    }
+  }
+  return "";
+}

--- a/promethee/parse_args.h
+++ b/promethee/parse_args.h
@@ -1,0 +1,9 @@
+#include <vector>
+#include <string>
+using namespace std;
+
+vector<string> convertToVector(int argc, char * argv[]);
+
+bool hasFlag(vector<string> & args, string flag);
+
+string getCmdOption(vector<string> & args, string cmd);

--- a/promethee/parse_directory.cpp
+++ b/promethee/parse_directory.cpp
@@ -50,3 +50,32 @@ vector<string> filterDirectoryFiles(string directoryName, string suffix){
     closedir(dirp);
     return files;
 };
+
+void parseInputAndMeta(vector<string> args, vector<string> & inputFiles, vector<string> & metaFiles, string &outputDirectory) {
+    const string INPUT_FILE_SUFFIX = ".input";
+    const string META_FILE_SUFFIX = ".meta";
+
+    const int INPUT_DIRECTORY_INDEX = 0;
+    const int META_DIRECTORY_INDEX = 1;
+    const int OUTPUT_DIRECTORY_INDEX = 2;
+
+    string inputDirectory = validDir(args[INPUT_DIRECTORY_INDEX]);
+    string metaDirectory = validDir(args[META_DIRECTORY_INDEX]);
+    outputDirectory = validDir(args[OUTPUT_DIRECTORY_INDEX]);
+
+    inputFiles = filterDirectoryFiles(inputDirectory, INPUT_FILE_SUFFIX);
+    metaFiles = filterDirectoryFiles(metaDirectory, META_FILE_SUFFIX);
+
+    sort(inputFiles.begin(), inputFiles.end());
+    sort(metaFiles.begin(), metaFiles.end());
+
+    if (inputFiles != metaFiles){ // files don't match
+        cerr << "Error: not every file has its metadata accordingly or vice versa\n";
+        exit(0);
+    }
+
+    for (int i = 0; i < inputFiles.size(); i++){
+        inputFiles[i] = inputDirectory + inputFiles[i] + INPUT_FILE_SUFFIX;
+        metaFiles[i] = metaDirectory + metaFiles[i] + META_FILE_SUFFIX;
+    }
+}

--- a/promethee/parse_directory.cpp
+++ b/promethee/parse_directory.cpp
@@ -1,0 +1,52 @@
+#include "parse_directory.h"
+
+string validDir(string directory){
+    if(directory.size() >= 1 && directory.back() != '/')
+        return directory + '/';
+    return directory;
+};
+
+bool endsWith(string text, string pattern){
+    bool result = false;
+    if(text.size() > pattern.size()){ 
+        string match = text.substr(text.size() - pattern.size(), pattern.size());
+        if(match == pattern)
+            result = true;
+    }
+    return result;
+}
+
+vector<string> readFiles(DIR* dir){
+    vector<string> fileNames;
+    struct dirent * directory;
+    while((directory = readdir(dir)) != NULL){
+        string fileName(directory->d_name);
+        fileNames.push_back(fileName);
+    }
+    return fileNames;
+}
+
+vector<string> filterDirectoryFiles(string directoryName, string suffix){
+    DIR* dirp = opendir(directoryName.c_str());
+    vector<string> files;
+    if(dirp){
+      
+        files = readFiles(dirp);
+      
+        auto iterator = remove_if(files.begin(), files.end(), [&](string fileName){
+            return ! endsWith(fileName, suffix);
+        });
+      
+        files.erase(iterator, files.end());
+      
+        for(string & file : files)
+            file = file.substr(0, file.size() - suffix.size());
+
+    } else {
+        cerr << "Directory " << directoryName.substr(0, directoryName.size() - 1) << " not found" << endl;
+        exit(0);
+    }
+    
+    closedir(dirp);
+    return files;
+};

--- a/promethee/parse_directory.h
+++ b/promethee/parse_directory.h
@@ -12,3 +12,5 @@ bool endsWith(string text, string pattern);
 vector<string> readFiles(DIR* dir);
 
 vector<string> filterDirectoryFiles(string directoryName, string suffix);
+
+void parseInputAndMeta(vector<string> args, vector<string> & inputFiles, vector<string> & metaFiles, string &outputDirectory);

--- a/promethee/parse_directory.h
+++ b/promethee/parse_directory.h
@@ -1,0 +1,14 @@
+#include <string>
+#include <vector>
+#include <dirent.h>
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+string validDir(string directory);
+
+bool endsWith(string text, string pattern);
+
+vector<string> readFiles(DIR* dir);
+
+vector<string> filterDirectoryFiles(string directoryName, string suffix);

--- a/promethee/promethee.cpp
+++ b/promethee/promethee.cpp
@@ -6,11 +6,8 @@ Promethee::Promethee(){
 
 }
 
-void Promethee::init(vector<string> inputFiles, vector<string> metaFiles, string pathToOutput, int divideBy){
-    this->inputFiles = inputFiles;
-    this->metaFiles = metaFiles;
-    this->pathToOutput = pathToOutput;
-    this->divideBy = divideBy;
+void Promethee::init(vector<string> args, int divideBy){
+    
 }
 
 void Promethee::process(){

--- a/promethee/promethee.cpp
+++ b/promethee/promethee.cpp
@@ -6,10 +6,11 @@ Promethee::Promethee(){
 
 }
 
-void Promethee::init(vector<string> inputFiles, vector<string> metaFiles, string pathToOutput){
+void Promethee::init(vector<string> inputFiles, vector<string> metaFiles, string pathToOutput, int divideBy){
     this->inputFiles = inputFiles;
     this->metaFiles = metaFiles;
     this->pathToOutput = pathToOutput;
+    this->divideBy = divideBy;
 }
 
 void Promethee::process(){

--- a/promethee/promethee.h
+++ b/promethee/promethee.h
@@ -12,7 +12,7 @@ struct Promethee{
 
     Promethee();
 
-    virtual void init(vector<string> inputFiles, vector<string> metaFiles, string pathToOutput, int divideBy) ;
+    virtual void init(vector<string> args, int divideBy) ;
 
     virtual void process();
 };

--- a/promethee/promethee.h
+++ b/promethee/promethee.h
@@ -8,10 +8,11 @@ struct Promethee{
 
     string pathToOutput;
     vector<string> inputFiles, metaFiles;
+    int divideBy;
 
     Promethee();
 
-    virtual void init(vector<string> inputFiles, vector<string> metaFiles, string pathToOutput) ;
+    virtual void init(vector<string> inputFiles, vector<string> metaFiles, string pathToOutput, int divideBy) ;
 
     virtual void process();
 };

--- a/promethee/vanilla/promethee_vanilla.cpp
+++ b/promethee/vanilla/promethee_vanilla.cpp
@@ -1,6 +1,8 @@
 #include "promethee_vanilla.h"
 #include "../inputreader.h"
 #include "../outputwriter.h"
+#include "../parse_directory.h"
+#include <algorithm>
 
 Data PrometheeVanilla::readData(){
   InputReader inputReader = InputReader();
@@ -14,6 +16,38 @@ Data PrometheeVanilla::readData(){
   return data;
 }
 
+void PrometheeVanilla::init(vector<string> args, int divideBy){
+	this->divideBy = divideBy;
+
+	const string INPUT_FILE_SUFFIX = ".input";
+	const string META_FILE_SUFFIX = ".meta";
+
+	const int INPUT_DIRECTORY_INDEX = 0;
+	const int META_DIRECTORY_INDEX = 1;
+	const int OUTPUT_DIRECTORY_INDEX = 2;
+
+	string inputDirectory = validDir(args[INPUT_DIRECTORY_INDEX]);
+	string metaDirectory = validDir(args[META_DIRECTORY_INDEX]);
+	string outputDirectory = validDir(args[OUTPUT_DIRECTORY_INDEX]);
+
+	vector<string> inputFiles = filterDirectoryFiles(inputDirectory, INPUT_FILE_SUFFIX);
+	vector<string> metaFiles = filterDirectoryFiles(metaDirectory, META_FILE_SUFFIX);
+
+	sort(inputFiles.begin(), inputFiles.end());
+	sort(metaFiles.begin(), metaFiles.end());
+
+	if (inputFiles != metaFiles){ // files don't match
+	}
+
+	for (int i = 0; i < inputFiles.size(); i++){
+		inputFiles[i] = inputDirectory + inputFiles[i] + INPUT_FILE_SUFFIX;
+		metaFiles[i] = metaDirectory + metaFiles[i] + META_FILE_SUFFIX;
+	}
+
+	this->inputFiles = inputFiles;
+	this->metaFiles = metaFiles;
+	this->pathToOutput = outputDirectory;
+}
 
 void PrometheeVanilla::process(){
 
@@ -31,6 +65,13 @@ void PrometheeVanilla::process(){
 
 	int studyArea = 0;
 
+	for(int line = 0; line < nlines; line++)
+		for(int column = 0; column < ncolumns; column++){
+			if(validPixels[line][column]){
+				studyArea++;
+			}
+		}
+
   	for(int criteria = 0; criteria < ncriterias; criteria++){
 
 		Matrix matrix = data.getCriteriaMatrix(criteria);
@@ -43,8 +84,6 @@ void PrometheeVanilla::process(){
 			cerr << (100.0 * (criteria * nlines + line + 1))/(ncriterias * nlines) << "%"<< endl;
 			for(int column = 0; column < ncolumns; column++){
 				if(!validPixels[line][column]) continue;
-				
-				studyArea += 1;
 				
 				for(register int line2 = 0; line2 < nlines; line2++){
 					for(register int column2 = 0; column2 < ncolumns; column2++){

--- a/promethee/vanilla/promethee_vanilla.cpp
+++ b/promethee/vanilla/promethee_vanilla.cpp
@@ -18,35 +18,7 @@ Data PrometheeVanilla::readData(){
 
 void PrometheeVanilla::init(vector<string> args, int divideBy){
 	this->divideBy = divideBy;
-
-	const string INPUT_FILE_SUFFIX = ".input";
-	const string META_FILE_SUFFIX = ".meta";
-
-	const int INPUT_DIRECTORY_INDEX = 0;
-	const int META_DIRECTORY_INDEX = 1;
-	const int OUTPUT_DIRECTORY_INDEX = 2;
-
-	string inputDirectory = validDir(args[INPUT_DIRECTORY_INDEX]);
-	string metaDirectory = validDir(args[META_DIRECTORY_INDEX]);
-	string outputDirectory = validDir(args[OUTPUT_DIRECTORY_INDEX]);
-
-	vector<string> inputFiles = filterDirectoryFiles(inputDirectory, INPUT_FILE_SUFFIX);
-	vector<string> metaFiles = filterDirectoryFiles(metaDirectory, META_FILE_SUFFIX);
-
-	sort(inputFiles.begin(), inputFiles.end());
-	sort(metaFiles.begin(), metaFiles.end());
-
-	if (inputFiles != metaFiles){ // files don't match
-	}
-
-	for (int i = 0; i < inputFiles.size(); i++){
-		inputFiles[i] = inputDirectory + inputFiles[i] + INPUT_FILE_SUFFIX;
-		metaFiles[i] = metaDirectory + metaFiles[i] + META_FILE_SUFFIX;
-	}
-
-	this->inputFiles = inputFiles;
-	this->metaFiles = metaFiles;
-	this->pathToOutput = outputDirectory;
+	parseInputAndMeta(args, this->inputFiles, this->metaFiles, this->pathToOutput);
 }
 
 void PrometheeVanilla::process(){

--- a/promethee/vanilla/promethee_vanilla.cpp
+++ b/promethee/vanilla/promethee_vanilla.cpp
@@ -29,6 +29,8 @@ void PrometheeVanilla::process(){
 	Matrix negativeFlow = Matrix(nlines, MatrixLine(ncolumns, 0.0));
 	Matrix netFlow = Matrix(nlines, MatrixLine(ncolumns, 0.0));
 
+	int studyArea = 0;
+
   	for(int criteria = 0; criteria < ncriterias; criteria++){
 
 		Matrix matrix = data.getCriteriaMatrix(criteria);
@@ -41,6 +43,9 @@ void PrometheeVanilla::process(){
 			cerr << (100.0 * (criteria * nlines + line + 1))/(ncriterias * nlines) << "%"<< endl;
 			for(int column = 0; column < ncolumns; column++){
 				if(!validPixels[line][column]) continue;
+				
+				studyArea += 1;
+				
 				for(register int line2 = 0; line2 < nlines; line2++){
 					for(register int column2 = 0; column2 < ncolumns; column2++){
 						if(validPixels[line2][column2] && 
@@ -61,11 +66,12 @@ void PrometheeVanilla::process(){
 
   	}
 
+	int denominator = (this->divideBy != -1 ? this->divideBy : studyArea);
 	// applying a not standard normalization (but used by grass)
 	for(int line = 0; line < nlines; line++)
 	for(int column = 0; column < ncolumns; column++){
-		positiveFlow[line][column] /= ncriterias;
-		negativeFlow[line][column] /= ncriterias;
+		positiveFlow[line][column] /= denominator;
+		negativeFlow[line][column] /= denominator;
 	}
 
 	// calculating global flow

--- a/promethee/vanilla/promethee_vanilla.h
+++ b/promethee/vanilla/promethee_vanilla.h
@@ -13,6 +13,7 @@
   struct PrometheeVanilla : Promethee {
     Data readData();
     void process();
+    void init(vector<string> args, int divideBy);
   };
 
 #endif


### PR DESCRIPTION
The flag -hq now is available you can use it like 
`./run samples/sample3/input samples/sample3/meta out/sample3 -hq=2`
also, the flag of vanilla was changed, to use vanilla you can run as in the example:
`./run -van samples/sample1/input samples/sample1/meta out/sample1 -hq=4`
And the main is simpler now

Solving #47 